### PR TITLE
[WIP]: Readme initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,23 +35,23 @@ Full documentation with example snippets here:<br /><a href='https://docs.tender
 
 ### Installation
 
-Available on npm as <a href='https://www.npmjs.com/package/tenderly-sdk-js'>tenderly-sdk-js</a>
+Available on npm as <a href='https://www.npmjs.com/package/tenderly-sdk-js'>tenderly-sdk</a>
 npm
 
 ```sh
-npm i tenderly-sdk-js
+npm i tenderly-sdk
 ```
 
 yarn
 
 ```sh
-yarn add tenderly-sdk-js
+yarn add tenderly-sdk
 ```
 
 pnpm
 
 ```sh
-pnpm add tenderly-sdk-js
+pnpm add tenderly-sdk
 ```
 
 ### Basic usage
@@ -59,7 +59,7 @@ pnpm add tenderly-sdk-js
 Instantiate a new tenderly instance
 
 ```ts
-import { Tenderly, Network } from 'tenderly-sdk-js';
+import { Tenderly, Network } from '@tenderly/sdk';
 
 const tenderlyInstance = new TenderlyInstance({
   accessKey: process.env.TENDERLY_ACCESS_KEY,


### PR DESCRIPTION
Preview of the readme: https://github.com/Tenderly/tenderly-sdk-js/blob/49eb024632d4185b6bd697fd1cfb1b0c540fe07a/README.md
Rewrote the `README.md` file based on a couple of repositories:

[Twilio Conversations SDK](https://sdk.twilio.com/js/conversations/releases/2.2.2/docs/index.html#twilio-conversations-client-library)
[redux](https://github.com/reduxjs/redux) ([examples](https://github.com/reduxjs/redux/tree/master/examples))
[sentry](https://github.com/getsentry/sentry-javascript) ([examples](https://github.com/getsentry/sentry-javascript/tree/develop/scenarios/browser))
[shopify](https://github.com/MONEI/Shopify-api-node)
[splunk](https://github.com/splunk/splunk-sdk-javascript) ([splunk examples](https://github.com/splunk/splunk-app-examples))

Additionally, I'm not sure what the structure of our docs page will be, i.e if we're going to have examples listed there, or have them reference this repository like tanstack-query does ([github](https://github.com/TanStack/query/tree/main/examples/react), [docs](https://tanstack.com/query/v4/docs/react/examples/react/simple)).

Here are some `CONTRIBUTING.md` examples:
[dogehouse](https://github.com/benawad/dogehouse/blob/staging/CONTRIBUTING.md)
[twilio-node](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md)
[redux](https://github.com/reduxjs/redux/blob/master/CONTRIBUTING.md)
[sentry](https://github.com/getsentry/sentry-javascript/blob/develop/CONTRIBUTING.md)


In my opinion, I'd keep it simple, with some basic setup, and an example to verify that users have configured there setup correctly. This is so that our users don't get overwhelmed with information on what to do with the SDK, and get them in the water as soon as possible.
Then link to our docs, or our examples, and see where we should go from there based on feedback from our users.
Currently there is not much to write about, as we only have wallets, contracts, contract verification, and simulations, but as we will be adding new features, I think that it would be better to link to the docs, and our examples page, so that users can choose which route to take.