### PR TITLE
TIC-498 `getAll` method should target v2 API

### DIFF
--- a/lib/repositories/contracts/contracts.repository.ts
+++ b/lib/repositories/contracts/contracts.repository.ts
@@ -206,7 +206,7 @@ export class ContractRepository implements Repository<TenderlyContract> {
 
   async getAll(): Promise<Contract[]> {
     try {
-      const wallets = await this.apiV1.get<{ accounts: ContractResponse[] }>(
+      const wallets = await this.apiV2.get<{ accounts: ContractResponse[] }>(
         `
       /accounts/${this.configuration.accountName}
       /projects/${this.configuration.projectName}


### PR DESCRIPTION
As the endpoint being generated (`/accounts/${accountName}/projects/${projectName}/accounts`) is a API v2 endpoint, this function should use v2, not v1.