### PR TITLE
Make 'TenderlySolcConfig' depend on 'SolcConfig', then modify the 'libraries' type

### DIFF
--- a/.changeset/rotten-jeans-reply.md
+++ b/.changeset/rotten-jeans-reply.md
@@ -1,0 +1,5 @@
+---
+'@tenderly/sdk': patch
+---
+
+Make TenderlySolcConfig dependent on SolcConfig

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,7 @@
       }
     ],
     "semi": ["warn", "always"],
-    "@typescript-eslint/no-unused-vars": "error"
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }]
   },
   "ignorePatterns": ["dist", "node_modules", "commitlint.config.js", "coverage", "prebuild.js"]
 }

--- a/lib/repositories/contracts/contracts.repository.ts
+++ b/lib/repositories/contracts/contracts.repository.ts
@@ -352,11 +352,7 @@ export class ContractRepository implements Repository<TenderlyContract> {
     if (!solcConfig?.settings?.libraries) {
       return tenderlySolcConfig;
     }
-    const libraries: {
-      [fileName: string]: {
-        addresses: { [libName: string]: string };
-      };
-    } = {};
+    const libraries: TenderlySolcConfig['settings']['libraries'] = {};
     for (const [fileName, libVal] of Object.entries(solcConfig.settings.libraries)) {
       if (libraries[fileName] === undefined) {
         libraries[fileName] = { addresses: {} };
@@ -380,11 +376,11 @@ export class ContractRepository implements Repository<TenderlyContract> {
   }
 
   _copySolcConfigToTenderlySolcConfig(solcConfig: SolcConfig): TenderlySolcConfig {
+    const { libraries: _, ...settings } = solcConfig.settings;
+
     return {
       version: solcConfig.version,
-      settings: {
-        optimizer: solcConfig.settings.optimizer,
-      },
+      settings: settings,
     };
   }
 }

--- a/lib/repositories/contracts/contracts.types.ts
+++ b/lib/repositories/contracts/contracts.types.ts
@@ -140,18 +140,8 @@ export type SolcConfig = {
 // also, sources shouldn't be included here as they are specified inside the verification request
 export type TenderlySolcConfig = {
   version: SolidityCompilerVersions;
-  settings: {
-    optimizer?: {
-      enabled: boolean;
-      runs?: number;
-    };
-    libraries?: {
-      [fileName: string]: {
-        addresses: {
-          [libName: string]: string;
-        };
-      };
-    };
+  settings: Omit<SolcConfig['settings'], 'libraries'> & {
+    libraries?: Record<string, { addresses: Record<string, string> }>;
   };
 };
 
@@ -166,15 +156,15 @@ export type VerificationRequest = {
 export type VerificationResponse = {
   compilation_errors: CompilationErrorResponse[];
   results: VerificationResult[];
-}
+};
 
-export type CompilationErrorResponse= {
+export type CompilationErrorResponse = {
   source_location: SourceLocation;
   error_ype: string;
   component: string;
   message: string;
   formatted_message: string;
-}
+};
 
 interface SourceLocation {
   file: string;
@@ -187,10 +177,10 @@ interface VerificationResult {
   verified_contract: InternalContract;
 }
 
-export type BytecodeMismatchErrorResponse= {
+export type BytecodeMismatchErrorResponse = {
   contract_id: string;
   expected: string;
   got: string;
   similarity: number;
   assumed_reason: string;
-}
+};


### PR DESCRIPTION
In order to expand the solidity compiler configuration that verification can have on the TenderlySDK, we need to make `TenderlySolcConfig` depend on the `SolcConfig` because there are slight changes between the real solidity compiler configuration and what TenderlySDK sends to the backend server.

This PR makes `TenderlySolcConfig`'s settings depend on `SolcConfig`'s settings.