### PR TITLE
Remove TenderlySolcConfig since it is not needed anymore

### DIFF
--- a/.changeset/cold-kiwis-rhyme.md
+++ b/.changeset/cold-kiwis-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@tenderly/sdk': patch
+---
+
+Repack libraries without `TenderlySolcConfig`

--- a/lib/repositories/contracts/contracts.types.ts
+++ b/lib/repositories/contracts/contracts.types.ts
@@ -1,4 +1,4 @@
-import { Network, Path, Web3Address } from '../../types';
+import { Network, Path } from '../../types';
 
 export interface Contract {
   address: string;
@@ -127,23 +127,10 @@ export type SolidityCompilerVersions = `v${number}.${number}.${number}`;
 export type SolcConfig = {
   version: SolidityCompilerVersions;
   sources: Record<Path, { content: string }>;
-  settings: {
-    optimizer?: {
-      enabled: boolean;
-      runs?: number;
-    };
-    libraries?: Record<Path, Record<string, Web3Address>>;
-  };
+  settings: unknown;
 };
 
-// TenderlySolcConfig is the same as SolcConfig, but with a different library structure for internal reasons
-// also, sources shouldn't be included here as they are specified inside the verification request
-export type TenderlySolcConfig = {
-  version: SolidityCompilerVersions;
-  settings: Omit<SolcConfig['settings'], 'libraries'> & {
-    libraries?: Record<string, { addresses: Record<string, string> }>;
-  };
-};
+export type TenderlySolcConfigLibraries = Record<string, { addresses: Record<string, string> }>;
 
 export type VerificationRequest = {
   contractToVerify: string;


### PR DESCRIPTION
`TenderlySolcConfig` is not needed anymore since the only difference from the `SolcConfig` is in the `libraries` field.

Since we are planning to mark `SolcConfig.settings` as an `unkown` type, there will be no `SolcConfig.settings.libraries`, thus, `TenderlySolcConfig` is not needed anymore.
