### PR TITLE
Repack libraries from `TenderlySolcConfig`

### DIFF
--- a/.changeset/cold-kiwis-rhyme.md
+++ b/.changeset/cold-kiwis-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@tenderly/sdk': patch
+---
+
+Repack libraries without `TenderlySolcConfig`

--- a/.changeset/warm-crews-hope.md
+++ b/.changeset/warm-crews-hope.md
@@ -1,0 +1,5 @@
+---
+'@tenderly/sdk': patch
+---
+
+Remove TenderlySolcConfig since it is not needed anymore


### PR DESCRIPTION
Since the `TenderlySolcConfig` is no longer needed, we are repacking the libraries in the `SolcConfig` itself.
